### PR TITLE
update current recipe on route change

### DIFF
--- a/frontend/all-recipes.ts
+++ b/frontend/all-recipes.ts
@@ -10,16 +10,14 @@ import {
 } from "lit-element";
 import { repeat } from "lit-html/directives/repeat";
 import RecipeInfo from "./generated/com/vaadin/recipes/data/RecipeInfo";
-import * as RecipeEndpoint from "./generated/RecipeEndpoint";
-import { updateCurrentRecipe } from ".";
-import { tsRecipeRoutes } from "./ts-routes";
-
-export const recipes: RecipeInfo[] = [];
 
 @customElement("all-recipes")
 export class AllRecipes extends LitElement {
   @property({ type: String })
   filter: string = "";
+
+  @property({ type: Array })
+  recipes: RecipeInfo[] = [];
 
   updateFilter = this.doUpdateFilter.bind(this);
 
@@ -47,7 +45,7 @@ export class AllRecipes extends LitElement {
 
       <ul>
         ${repeat(
-          recipes.filter((recipe) =>
+          this.recipes.filter((recipe) =>
             recipe.howDoI.toLowerCase().includes(this.filter)
           ),
           (recipe) => recipe.url,
@@ -58,16 +56,6 @@ export class AllRecipes extends LitElement {
     `;
   }
 
-  async connectedCallback() {
-    super.connectedCallback();
-    recipes.push(...tsRecipeRoutes.map((route) => route.info));
-    recipes.push(...(await RecipeEndpoint.list()));
-    recipes.sort((a, b) =>
-      a.howDoI < b.howDoI ? -1 : a.howDoI == b.howDoI ? 0 : 1
-    );
-    await this.requestUpdate();
-    updateCurrentRecipe();
-  }
   doUpdateFilter() {
     this.filter = this.filterField?.value.toLowerCase() || "";
   }

--- a/frontend/index.ts
+++ b/frontend/index.ts
@@ -1,7 +1,5 @@
 import { Flow } from "@vaadin/flow-frontend/Flow";
 import { Route, Router } from "@vaadin/router";
-import { recipes } from "./all-recipes";
-import { MainView } from "./views/main-view";
 import { tsRecipeRoutes } from "./ts-routes";
 
 const { serverSideRoutes } = new Flow({
@@ -14,7 +12,6 @@ const routes: Route[] = [
     component: "main-view",
     action: async (_context, _commands) => {
       await import("./views/main-view");
-      updateCurrentRecipe(_context.pathname);
     },
     children: [
       {
@@ -33,17 +30,3 @@ const routes: Route[] = [
 export const router = new Router(document.querySelector("#outlet"));
 router.setRoutes(routes);
 
-export const updateCurrentRecipe = (path?: string) => {
-  if (!path) {
-    path = router.location.pathname;
-  }
-
-  if (path.includes("-")) {
-    const tag = path.substr(path.lastIndexOf("/") + 1);
-    const recipe = recipes.find((recipe) => recipe.url == tag);
-    if (recipe) {
-      const mainView = document.querySelector("main-view")! as MainView;
-      mainView.recipe = recipe;
-    }
-  }
-};

--- a/frontend/views/main-view.ts
+++ b/frontend/views/main-view.ts
@@ -3,15 +3,21 @@ import "@vaadin/vaadin-app-layout/theme/lumo/vaadin-app-layout";
 import "@vaadin/vaadin-app-layout/vaadin-drawer-toggle";
 import "@vaadin/vaadin-split-layout";
 import "@vaadin/vaadin-tabs";
-import { css, customElement, html, LitElement, property } from "lit-element";
+import { css, customElement, html, LitElement, property, internalProperty } from "lit-element";
 import "../all-recipes";
 import "../code-viewer";
 import RecipeInfo from "../generated/com/vaadin/recipes/data/RecipeInfo";
+import { tsRecipeRoutes } from "../ts-routes";
+import * as RecipeEndpoint from "../generated/RecipeEndpoint";
+import { router } from "..";
 
 @customElement("main-view")
 export class MainView extends LitElement {
   @property({ type: Object })
   recipe: RecipeInfo = { howDoI: "", url: "", tags: [] };
+
+  @internalProperty()
+  private recipes: RecipeInfo[] = [];
 
   static get styles() {
     return css`
@@ -36,6 +42,11 @@ export class MainView extends LitElement {
     `;
   }
 
+  constructor(){
+    super();
+    this._routerLocationChanged = this._routerLocationChanged.bind(this);
+  }
+
   render() {
     return html`
       <vaadin-app-layout primary-section="drawer">
@@ -47,7 +58,7 @@ export class MainView extends LitElement {
             (tag) => html`<span class="tag">${tag}</span>`
           )}<span class="title">How do I ${this.recipe.howDoI}</span>
         </span>
-        <all-recipes slot="drawer"></all-recipes>
+        <all-recipes slot="drawer" .recipes=${this.recipes}></all-recipes>
         <vaadin-split-layout class="layout" orientation="vertical">
           <div class="examplewrapper">
             <div>${this.recipe.description}</div>
@@ -61,14 +72,22 @@ export class MainView extends LitElement {
 
   private _routerLocationChanged() {
     AppLayoutElement.dispatchCloseOverlayDrawerEvent();
+    this._updateCurrentRecipe(router.location.pathname);
   }
 
-  connectedCallback() {
+  async connectedCallback() {
     super.connectedCallback();
     window.addEventListener(
       "vaadin-router-location-changed",
       this._routerLocationChanged
     );
+
+    this.recipes = [...this.recipes, 
+      ...tsRecipeRoutes.map((route) => route.info),
+      ...(await RecipeEndpoint.list())]
+      .sort((a, b) => a.howDoI < b.howDoI ? -1 : a.howDoI == b.howDoI ? 0 : 1);
+    
+    this._updateCurrentRecipe(router.location.pathname);
   }
 
   disconnectedCallback() {
@@ -77,5 +96,16 @@ export class MainView extends LitElement {
       "vaadin-router-location-changed",
       this._routerLocationChanged
     );
+  }
+
+
+  _updateCurrentRecipe(path: string) {  
+    if (path.includes("-")) {
+      const tag = path.substr(path.lastIndexOf("/") + 1);
+      const recipe = this.recipes.find((recipe) => recipe.url == tag);
+      if (recipe) {
+        this.recipe = recipe;
+      }
+    }
   }
 }


### PR DESCRIPTION
Currently, by design, the route action is always called for route resolution. So it should not be used for updating the current recipe, even though it's quite intuitive to do that. More details in [this ticket](https://github.com/vaadin/vaadin-router/issues/354).

Instead, I think it would be better to update the header/footer on route change. In this way, the routing looks less broken.