### PR TITLE
Fix source file link

### DIFF
--- a/src/main/java/com/vaadin/recipes/recipe/copytoclipboard/CopyToClipboard.java
+++ b/src/main/java/com/vaadin/recipes/recipe/copytoclipboard/CopyToClipboard.java
@@ -10,8 +10,8 @@ import com.vaadin.recipes.recipe.Metadata;
 import com.vaadin.recipes.recipe.Recipe;
 
 @Route("copy-to-clipboard")
-@Metadata(howdoI = "Copy text to clipboard", description = "How to copy text to the user's clipboard when clicking a button", sourceFiles = {
-        "./recipe/copytoclipboard/copytoclipboard.js" })
+@Metadata(howdoI = "Copy text to clipboard", description = "How to copy text to the user's clipboard when clicking a button",
+        sourceFiles = { "recipe/copytoclipboard/copytoclipboard.js" })
 @JsModule("./recipe/copytoclipboard/copytoclipboard.js")
 public class CopyToClipboard extends Recipe {
 


### PR DESCRIPTION
Not sure if this will fix it... but the other recipes do not have a leading `./` in the source file links.

Either way works for me locally, but it seems the current link does not work on cookbook.vaadin.com. When selecting the `js` file, I get `<Not found>`.
https://cookbook.vaadin.com/copy-to-clipboard
