### PR TITLE
Use Span instead of Label as generic text containers

### DIFF
--- a/src/main/java/com/vaadin/recipes/recipe/alwayseditablelabel/AlwaysEditableLabel.java
+++ b/src/main/java/com/vaadin/recipes/recipe/alwayseditablelabel/AlwaysEditableLabel.java
@@ -9,8 +9,8 @@ import com.vaadin.recipes.recipe.Tag;
 
 @Route("always-editable-label")
 @Metadata(
-        howdoI = "Create an always-editable Span",
-        description = "Create a component with text label that is always in editable mode.",
+        howdoI = "Create an always-editable label",
+        description = "Create a component with a text label that is always in editable mode.",
         tags = { Tag.JAVA })
 public class AlwaysEditableLabel extends Recipe {
 

--- a/src/main/java/com/vaadin/recipes/recipe/alwayseditablelabel/AlwaysEditableLabel.java
+++ b/src/main/java/com/vaadin/recipes/recipe/alwayseditablelabel/AlwaysEditableLabel.java
@@ -1,6 +1,6 @@
 package com.vaadin.recipes.recipe.alwayseditablelabel;
 
-import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.router.Route;
 import com.vaadin.recipes.recipe.Metadata;
@@ -9,18 +9,17 @@ import com.vaadin.recipes.recipe.Tag;
 
 @Route("always-editable-label")
 @Metadata(
-        howdoI = "Create an always-editable Label",
-        description = "Create a Label component that is always in editable mode.",
+        howdoI = "Create an always-editable Span",
+        description = "Create a component with text label that is always in editable mode.",
         tags = { Tag.JAVA })
 public class AlwaysEditableLabel extends Recipe {
 
     public AlwaysEditableLabel() {
-        Label label = new Label("I'm an editable label ... ");
+        Span label = new Span("I'm an editable label ... ");
         label.getElement().setAttribute("contenteditable", true);
 
         label.getElement().addEventListener("input",
-                e -> Notification.show("Value changed: "
-                        + e.getEventData().getString("event.target.innerHTML")))
+                e -> Notification.show("Value changed: " + e.getEventData().getString("event.target.innerHTML")))
                 .addEventData("event.target.innerHTML");
 
         add(label);

--- a/src/main/java/com/vaadin/recipes/recipe/editablelabelondblclick/EditableLabelOnDblClick.java
+++ b/src/main/java/com/vaadin/recipes/recipe/editablelabelondblclick/EditableLabelOnDblClick.java
@@ -1,6 +1,5 @@
 package com.vaadin.recipes.recipe.editablelabelondblclick;
 
-import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
@@ -10,7 +9,7 @@ import com.vaadin.recipes.recipe.Tag;
 
 @Route("editable-label-on-dblclick")
 @Metadata(
-        howdoI = "create an editable Span when double-clicked",
+        howdoI = "create an editable label when double-clicked",
         description = "Create a text label that can turn into a text field for editing on double-click.",
         tags = { Tag.JAVA })
 public class EditableLabelOnDblClick extends Recipe {

--- a/src/main/java/com/vaadin/recipes/recipe/editablelabelondblclick/EditableLabelOnDblClick.java
+++ b/src/main/java/com/vaadin/recipes/recipe/editablelabelondblclick/EditableLabelOnDblClick.java
@@ -1,6 +1,7 @@
 package com.vaadin.recipes.recipe.editablelabelondblclick;
 
 import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
 import com.vaadin.recipes.recipe.Metadata;
@@ -9,14 +10,14 @@ import com.vaadin.recipes.recipe.Tag;
 
 @Route("editable-label-on-dblclick")
 @Metadata(
-        howdoI = "create an editable Label when double-clicked", 
-        description = "Create a Label that can turn into a text field for editing on double-click.",
+        howdoI = "create an editable Span when double-clicked",
+        description = "Create a text label that can turn into a text field for editing on double-click.",
         tags = { Tag.JAVA })
 public class EditableLabelOnDblClick extends Recipe {
 
     public EditableLabelOnDblClick() {
         String initialContent = "Double-click me to edit ...";
-        Label label = new Label(initialContent);
+        Span label = new Span(initialContent);
         TextField textField = new TextField();
         textField.setValue(initialContent);
 


### PR DESCRIPTION
The label HTML element is only intended to be used as form field
captions