### PR TITLE
Integrate vaadin.com header-as-a-service

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -68,7 +68,7 @@
       .forEach((link) => document.head.append(link));
   </script>
   <script type="text/javascript"
-    src="https://preview.vaadin.com/vaadincom/haas-service/haas-loader.js?linkBaseHref=https://vaadin.com"
+    src="https://vaadin.com/vaadincom/haas-service/haas-loader.js?linkBaseHref=https://vaadin.com"
     defer="true"></script>
 </body>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,75 +1,91 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="google-site-verification"
+      content="vyAh4OVPhguDpAXWzOn41GRLH_-7yJbsl71CTMpI8HI"
+    />
+    <title>Vaadin Cookbook - code snippets for common tasks</title>
+    <meta
+      name="description"
+      content="Find ready to use solutions and code snippets for common development problems and UX patterns. Includes Vaadin examples in Java and TypeScript."
+    />
+    <meta
+      property="og:image"
+      content="https://cookbook.vaadin.com/images/vaadin-cookbook-featured.png"
+    />
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="google-site-verification" content="vyAh4OVPhguDpAXWzOn41GRLH_-7yJbsl71CTMpI8HI" />
-  <title>Vaadin Cookbook - code snippets for common tasks</title>
-  <meta name="description"
-    content="Find ready to use solutions and code snippets for common development problems and UX patterns. Includes Vaadin examples in Java and TypeScript." />
-  <meta property="og:image" content="https://cookbook.vaadin.com/images/vaadin-cookbook-featured.png" />
+    <!-- index.ts is included here automatically (either by the dev server or during the build) -->
+    <style>
+      html {
+        background-color: var(--color-alloy-lighter);
+      }
 
-  <!-- index.ts is included here automatically (either by the dev server or during the build) -->
-  <style>
-    html {
-      background-color: var(--color-alloy-lighter);
-    }
+      body {
+        margin: 0;
+      }
 
-    body {
-      margin: 0;
-    }
+      #haas-container {
+        background-color: var(--color-charcoal-darker);
+        height: var(--mainViewMenuHeight);
+        position: relative;
+        z-index: 9999;
+      }
 
-    #haas-container {
-      background-color: var(--color-charcoal-darker);
-      height: var(--mainViewMenuHeight);
-      position: relative;
-      z-index: 9999;
-    }
+      [hidden] {
+        display: none !important;
+      }
+    </style>
+  </head>
 
-    [hidden] {
-      display: none !important;
-    }
-  </style>
-</head>
+  <body>
+    <div id="haas-container"></div>
+    <div id="outlet"></div>
 
-<body>
-  <div id="haas-container"></div>
-  <div id="outlet"></div>
+    <!-- Vaadin.com Header-as-a-Service -->
+    <script>
+      const haasCSS = [
+        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/icons/css/line-awesome.min.css",
+        "https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;700&display=swap",
+        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/haas-bundle.css",
+        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/2-components/fields.css",
+      ];
 
-  <!-- Vaadin.com Header-as-a-Service -->
-  <script>
-    const haasCSS = [
-      "https://cdn.vaadin.com/vaadin-design-system/latest/assets/icons/css/line-awesome.min.css",
-      "https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;700&display=swap",
-      "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/haas-bundle.css",
-      "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/2-components/fields.css",
-    ];
+      // Preload
+      haasCSS
+        .map((url) => {
+          const link = document.createElement("link");
+          link.setAttribute("rel", "preload");
+          link.setAttribute("as", "style");
+          link.setAttribute("href", url);
+          return link;
+        })
+        .forEach((link) => document.head.append(link));
 
-    // Preload
-    haasCSS
-      .map((url) => {
-        const link = document.createElement("link");
-        link.setAttribute("rel", "preload");
-        link.setAttribute("as", "style");
-        link.setAttribute("href", url);
-        return link;
-      })
-      .forEach((link) => document.head.append(link));
-
-    // Import
-    haasCSS
-      .map((url) => {
-        const link = document.createElement("link");
-        link.setAttribute("rel", "stylesheet");
-        link.setAttribute("href", url);
-        return link;
-      })
-      .forEach((link) => document.head.append(link));
-  </script>
-  <script type="text/javascript"
-    src="https://vaadin.com/vaadincom/haas-service/haas-loader.js?linkBaseHref=https://vaadin.com"
-    defer="true"></script>
-</body>
-
+      // Import
+      haasCSS
+        .map((url) => {
+          const link = document.createElement("link");
+          link.setAttribute("rel", "stylesheet");
+          link.setAttribute("href", url);
+          return link;
+        })
+        .forEach((link) => document.head.append(link));
+    </script>
+    <script>
+      if (
+        location.hostname !== "localhost" &&
+        location.hostname !== "127.0.0.1"
+      ) {
+        const s = document.createElement("script");
+        s.type = "text/javascript";
+        s.src =
+          "https://vaadin.com/vaadincom/haas-service/haas-loader.js?linkBaseHref=https://vaadin.com";
+        s.defer = true;
+        document.head.appendChild(s);
+      }
+    </script>
+  </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,31 +16,6 @@
       property="og:image"
       content="https://cookbook.vaadin.com/images/vaadin-cookbook-featured.png"
     />
-    <!-- Google Analytics -->
-    <script>
-      (function (i, s, o, g, r, a, m) {
-        i["GoogleAnalyticsObject"] = r;
-        (i[r] =
-          i[r] ||
-          function () {
-            (i[r].q = i[r].q || []).push(arguments);
-          }),
-          (i[r].l = 1 * new Date());
-        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-        a.async = 1;
-        a.src = g;
-        m.parentNode.insertBefore(a, m);
-      })(
-        window,
-        document,
-        "script",
-        "https://www.google-analytics.com/analytics.js",
-        "ga"
-      );
-
-      ga("create", "UA-658457-8", "auto");
-    </script>
-    <!-- End Google Analytics -->
 
     <!-- index.ts is included here automatically (either by the dev server or during the build) -->
     <style>
@@ -52,30 +27,11 @@
         margin: 0;
       }
 
-      .vcom-header {
-        display: flex;
-        align-items: center;
-        color: #fff;
+      #haas-container {
         background-color: var(--color-charcoal-darker);
-        min-height: var(--mainViewMenuHeight);
-      }
-
-      .vcom-header .vcom-link {
-        display: block;
-        width: 110px;
-        height: 25px;
-        background: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNTAgMzQuNjciPjx0aXRsZT52YWFkaW5sb2dvPC90aXRsZT48cGF0aCBkPSJNMTQ5Ljk1IDE3LjMzYTIgMiAwIDAgMC0xLjItMS44NmgtLjA4TDEzNS40OCA4LjNhMi4yOCAyLjI4IDAgMCAwLTMuNDIgMiAyLjIzIDIuMjMgMCAwIDAgMS41NiAyLjE3bDkuMTEgNC44OS05LjEgNC44OGEyLjIzIDIuMjMgMCAwIDAtMS41NyAyLjE3IDIuMjggMi4yOCAwIDAgMCAzLjQyIDJsMTMuMTktNy4xM2guMDZhMiAyIDAgMCAwIDEuMjMtMS44N20tMTkuNi0uMDlhMS44MiAxLjgyIDAgMCAwLTEuODItMS44MmgtLjQ0YTEuNzMgMS43MyAwIDAgMS0xLjcyLTEuNzNWNC40NEE0LjQzIDQuNDMgMCAwIDAgMTIxLjk1IDBoLTMuNDFhMS43IDEuNyAwIDAgMC0uODQgMy4xOSAxLjcgMS43IDAgMCAwIC44My4yMmgxLjA3YTEuNzMgMS43MyAwIDAgMSAxLjczIDEuNzN2OC40NmEzLjY1IDMuNjUgMCAwIDAgMy4xIDMuNjEgNS4zOCA1LjM4IDAgMCAwIC45LjA5di4wOGE1LjM4IDUuMzggMCAwIDAtLjkuMDkgMy42NSAzLjY1IDAgMCAwLTMuMSAzLjYxdjguNDVhMS43MyAxLjczIDAgMCAxLTEuNzMgMS43M2gtMS4wN2ExLjcgMS43IDAgMCAwLS44My4yMiAxLjcgMS43IDAgMCAwIC44NCAzLjE5aDMuNDFhNC40MyA0LjQzIDAgMCAwIDQuNDMtNC40NFYyMC45YTEuNzMgMS43MyAwIDAgMSAxLjcyLTEuNzNoLjQ0YTEuODIgMS44MiAwIDAgMCAxLjgyLTEuODJ6IiBmaWxsPSIjMDBiNGYwIi8+PHBhdGggZD0iTTUxIDcuNjRBOS44NyA5Ljg3IDAgMSAwIDU2IDI2YTIuNTQgMi41NCAwIDAgMCA0LjgxLTEuMTR2LTcuMzVBOS44NyA5Ljg3IDAgMCAwIDUxIDcuNjR6bTAgMTQuNjRhNC43NyA0Ljc3IDAgMSAxIDQuNzctNC43N0E0Ljc3IDQuNzcgMCAwIDEgNTEgMjIuMjh6TTE5IDEwLjE2YTIuNTQgMi41NCAwIDAgMC00LjgtMS4wOWwtNC43MSA5Ljg2LTQuNzEtOS44NnYtLjA1bC0uMDctLjEzLS4wNi0uMS0uMDctLjEtLjA4LS4xMS0uMDktLjA4LS4xLS4xMS0uMDctLjA3LS4xMS0uMUw0IDguMTZsLS4xLS4wOEwzLjg0IDhoLS4xbC0uMTMtLjA3aC0uMDhsLS4xNS0uMDZIMS44M2wtLjE3LjA1aC0uMDdsLS4xOC4wN0wxLjIgOGgtLjA3TDEgOC4xMWwtLjA4LjA2LS4xMS4wOS0uMDguMDctLjA5LjEtLjA3LjA4LS4wOS4xMS0uMDcuMDgtLjA5LjEzdi4wN2wtLjEyLjE1di4wNmwtLjA3LjE3di4wNkwwIDkuNTF2MS41OWwuMDcuMTYgNyAxNC42MWEyLjU0IDIuNTQgMCAwIDAgNC42Mi4wNWw3LTE0LjY2YTIuNTMgMi41MyAwIDAgMCAuMzEtMS4xem0xMC4yMi0yLjUyQTkuODcgOS44NyAwIDEgMCAzNC4yOCAyNmEyLjU0IDIuNTQgMCAwIDAgNC44MS0xLjE0di03LjM1YTkuODcgOS44NyAwIDAgMC05Ljg3LTkuODd6bTAgMTQuNjRBNC43NyA0Ljc3IDAgMSAxIDM0IDE3LjUxYTQuNzcgNC43NyAwIDAgMS00Ljc4IDQuNzd6TTgyLjQyIDE3VjIuODhhMi41NCAyLjU0IDAgMCAwLTUuMDggMHY2QTkuODcgOS44NyAwIDEgMCA3Ny42MSAyNmEyLjU0IDIuNTQgMCAwIDAgNC44MS0xLjE0di03LjM4YzAtLjE3LjAxLS4zMiAwLS40OHptLTkuODYgNS4zYTQuNzcgNC43NyAwIDEgMSA0Ljc3LTQuNzcgNC43NyA0Ljc3IDAgMCAxLTQuNzYgNC43NXoiIGZpbGw9IiNmOGY4ZjgiLz48Y2lyY2xlIGN4PSI4OC45NSIgY3k9IjIuODgiIHI9IjIuNTQiIGZpbGw9IiNmOGY4ZjgiLz48cGF0aCBkPSJNODkgNy42NGEyLjU0IDIuNTQgMCAwIDAtMi41NCAyLjU0djE0LjY3YTIuNTQgMi41NCAwIDEgMCA1LjA4IDBWMTAuMThBMi41NCAyLjU0IDAgMCAwIDg5IDcuNjR6bTE2Ljc0LjU1YTcuNzkgNy43OSAwIDAgMC00Ljg0IDEuNjggMi41NCAyLjU0IDAgMCAwLTUuMDYuMzF2MTQuNjdhMi41NCAyLjU0IDAgMCAwIDUuMDggMHYtNy43MmEzLjc4IDMuNzggMCAxIDEgNy41NyAwdjcuNzJhMi41NCAyLjU0IDAgMCAwIDUuMDggMFYxNmE3LjgzIDcuODMgMCAwIDAtNy44My03LjgxeiIgZmlsbD0iI2Y4ZjhmOCIvPjwvc3ZnPg==)
-          no-repeat;
-        background-size: 100%;
-      }
-
-      .visually-hidden {
-        position: absolute !important;
-        height: 1px;
-        width: 1px;
-        overflow: hidden;
-        clip: rect(1px, 1px, 1px, 1px);
-        white-space: nowrap;
+        height: var(--mainViewMenuHeight);
+        position: relative;
+        z-index: 9999;
       }
 
       [hidden] {
@@ -85,30 +41,31 @@
   </head>
 
   <body>
-    <div class="vcom-header">
-      <div class="container-fluid" style="width: 100%">
-        <a href="https://vaadin.com" class="vcom-link">
-          <span class="visually-hidden">Vaadin</span>
-        </a>
-      </div>
-    </div>
+    <div id="haas-container"></div>
     <div id="outlet"></div>
 
+    <!-- Vaadin.com Header-as-a-Service -->
     <script>
-      // Loading CSS here so they don't block the bundle download
-      // TODO: remove duplicate stylesheets when taking vaadin.com Header-as-a-service (HaaS) into use
-      const designSystemCSS = [
-        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/1-foundation/custom-properties.css",
-        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/1-foundation/reset.css",
-        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/1-foundation/layout.css",
+      const haasCSS = [
+        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/icons/css/line-awesome.min.css",
+        "https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;700&display=swap",
+        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/haas-bundle.css",
         "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/2-components/fields.css",
-        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/2-components/links.css",
-        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/2-components/tag.css",
-        "https://cdn2.hubspot.net/hubfs/1840687/Design%20System/icons/css/line-awesome.min.css",
-        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/1-foundation/typography.css",
       ];
 
-      designSystemCSS
+      // Preload
+      haasCSS
+        .map((url) => {
+          const link = document.createElement("link");
+          link.setAttribute("rel", "preload");
+          link.setAttribute("as", "style");
+          link.setAttribute("href", url);
+          return link;
+        })
+        .forEach((link) => document.head.append(link));
+
+      // Import
+      haasCSS
         .map((url) => {
           const link = document.createElement("link");
           link.setAttribute("rel", "stylesheet");
@@ -117,5 +74,6 @@
         })
         .forEach((link) => document.head.append(link));
     </script>
+    <script type="text/javascript" src="https://preview.vaadin.com/vaadincom/haas-service/haas-loader.js" defer="true"></script>
   </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,6 +17,58 @@
       content="https://cookbook.vaadin.com/images/vaadin-cookbook-featured.png"
     />
 
+    <link
+      rel="preload"
+      as="style"
+      href="https://cdn.vaadin.com/vaadin-design-system/latest/assets/icons/css/line-awesome.min.css"
+    />
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;700&display=swap"
+    />
+    <link
+      rel="preload"
+      as="style"
+      href="https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/haas-bundle.css"
+    />
+    <link
+      rel="preload"
+      as="style"
+      href="https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/2-components/fields.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.vaadin.com/vaadin-design-system/latest/assets/icons/css/line-awesome.min.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;700&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/haas-bundle.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/2-components/fields.css"
+    />
+
+    <script>
+      // Load header-as-a service if not on localhost
+      if (
+        location.hostname !== "localhost" &&
+        location.hostname !== "127.0.0.1"
+      ) {
+        const s = document.createElement("script");
+        s.type = "text/javascript";
+        s.src =
+          "https://vaadin.com/vaadincom/haas-service/haas-loader.js?linkBaseHref=https://vaadin.com";
+        s.defer = true;
+        document.head.appendChild(s);
+      }
+    </script>
+
     <!-- index.ts is included here automatically (either by the dev server or during the build) -->
     <style>
       html {
@@ -43,49 +95,5 @@
   <body>
     <div id="haas-container"></div>
     <div id="outlet"></div>
-
-    <!-- Vaadin.com Header-as-a-Service -->
-    <script>
-      const haasCSS = [
-        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/icons/css/line-awesome.min.css",
-        "https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;700&display=swap",
-        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/haas-bundle.css",
-        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/2-components/fields.css",
-      ];
-
-      // Preload
-      haasCSS
-        .map((url) => {
-          const link = document.createElement("link");
-          link.setAttribute("rel", "preload");
-          link.setAttribute("as", "style");
-          link.setAttribute("href", url);
-          return link;
-        })
-        .forEach((link) => document.head.append(link));
-
-      // Import
-      haasCSS
-        .map((url) => {
-          const link = document.createElement("link");
-          link.setAttribute("rel", "stylesheet");
-          link.setAttribute("href", url);
-          return link;
-        })
-        .forEach((link) => document.head.append(link));
-    </script>
-    <script>
-      if (
-        location.hostname !== "localhost" &&
-        location.hostname !== "127.0.0.1"
-      ) {
-        const s = document.createElement("script");
-        s.type = "text/javascript";
-        s.src =
-          "https://vaadin.com/vaadincom/haas-service/haas-loader.js?linkBaseHref=https://vaadin.com";
-        s.defer = true;
-        document.head.appendChild(s);
-      }
-    </script>
   </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -67,7 +67,8 @@
       })
       .forEach((link) => document.head.append(link));
   </script>
-  <script type="text/javascript" src="https://preview.vaadin.com/vaadincom/haas-service/haas-loader.js"
+  <script type="text/javascript"
+    src="https://preview.vaadin.com/vaadincom/haas-service/haas-loader.js?linkBaseHref=https://vaadin.com"
     defer="true"></script>
 </body>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -98,14 +98,14 @@
       // Loading CSS here so they don't block the bundle download
       // TODO: remove duplicate stylesheets when taking vaadin.com Header-as-a-service (HaaS) into use
       const designSystemCSS = [
-        "https://vaadin.com/frontend/design-system/src/assets/css/1-foundation/custom-properties.css",
-        "https://vaadin.com/frontend/design-system/src/assets/css/1-foundation/reset.css",
-        "https://vaadin.com/frontend/design-system/src/assets/css/1-foundation/layout.css",
-        "https://vaadin.com/frontend/design-system/src/assets/css/2-components/fields.css",
-        "https://vaadin.com/frontend/design-system/src/assets/css/2-components/links.css",
-        "https://vaadin.com/frontend/design-system/src/assets/css/2-components/tag.css",
+        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/1-foundation/custom-properties.css",
+        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/1-foundation/reset.css",
+        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/1-foundation/layout.css",
+        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/2-components/fields.css",
+        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/2-components/links.css",
+        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/2-components/tag.css",
         "https://cdn2.hubspot.net/hubfs/1840687/Design%20System/icons/css/line-awesome.min.css",
-        "https://vaadin.com/frontend/design-system/src/assets/css/1-foundation/typography.css",
+        "https://cdn.vaadin.com/vaadin-design-system/latest/assets/css/1-foundation/typography.css",
       ];
 
       designSystemCSS

--- a/frontend/index.ts
+++ b/frontend/index.ts
@@ -1,5 +1,5 @@
 import { Flow } from "@vaadin/flow-frontend/Flow";
-import { Route, Router, RouterLocation } from "@vaadin/router";
+import { Route, Router } from "@vaadin/router";
 import { tsRecipeRoutes } from "./ts-routes";
 import RecipeInfo from "./generated/com/vaadin/recipes/data/RecipeInfo";
 import * as RecipeEndpoint from "./generated/RecipeEndpoint";
@@ -47,14 +47,10 @@ async function initRecipes() {
   }
 }
 
-// Log page updates to GA
-function sendPageview(e: CustomEvent) {
-  const routerLocation = e.detail.location as RouterLocation;
-  if (location.hostname === "localhost" || location.hostname === "127.0.0.1") {
-    console.log("Location changed. GA disabled locally.", routerLocation);
-  } else {
-    ga("set", "page", routerLocation.pathname);
-    ga("send", "pageview");
+function sendPageview() {
+  if (location.hostname !== "localhost" && location.hostname !== "127.0.0.1") {
+    // Let vaadin.com HaaS know that the page has changed
+    window.dispatchEvent(new Event('on-location-change'));
   }
 }
 window.addEventListener(

--- a/frontend/views/recipes-list-view.ts
+++ b/frontend/views/recipes-list-view.ts
@@ -420,13 +420,17 @@ export class RecipesListView extends LitElement {
   logSearch() {
     if (!this.filter) return;
 
-    if (
-      location.hostname === "localhost" ||
-      location.hostname === "127.0.0.1"
-    ) {
-      console.log(`Search event: "${this.filter}". GA disabled locally.`);
+    if ("haas" in window) {
+      //@ts-ignore
+      window.haas.tracker.gtm.triggerGAEvent(
+        "send",
+        "event",
+        "cookbook",
+        "search",
+        this.filter
+      );
     } else {
-      ga("send", "event", "cookbook", "search", this.filter);
+      console.log(`Search event: "${this.filter}". GA disabled locally.`);
     }
   }
 

--- a/frontend/views/recipes-list-view.ts
+++ b/frontend/views/recipes-list-view.ts
@@ -333,7 +333,7 @@ export class RecipesListView extends LitElement {
             </h6>
             <vaadin-checkbox-group @value-changed=${this.tagFilterChange}>
               ${this.tags.map(
-      (tag) => html`
+                (tag) => html`
                   <vaadin-checkbox
                     value="${tag}"
                     ?checked=${this.filterTags.includes(tag)}
@@ -346,23 +346,23 @@ export class RecipesListView extends LitElement {
                     ></vaadin-checkbox
                   >
                 `
-    )}
+              )}
             </vaadin-checkbox-group>
           </vaadin-details>
         </div>
         <ul class="recipes-list">
           ${repeat(
-      recipes.filter((recipe) =>
-        this.recipeMatches(recipe, this.filter, this.filterTags)
-      ),
-      (recipe) => recipe.url,
-      (recipe) =>
-        html` <li class="recipe">
+            recipes.filter((recipe) =>
+              this.recipeMatches(recipe, this.filter, this.filterTags)
+            ),
+            (recipe) => recipe.url,
+            (recipe) =>
+              html` <li class="recipe">
                 <h5 class="recipe-title">
                   <a href="${recipe.url}"
                     >${recipe.howDoI
-            .trim()
-            .replace(/^\w/, (c) => c.toUpperCase())}</a
+                      .trim()
+                      .replace(/^\w/, (c) => c.toUpperCase())}</a
                   >
                 </h5>
                 <p
@@ -373,16 +373,16 @@ export class RecipesListView extends LitElement {
                 </p>
                 <div class="recipe-tags">
                   ${recipe.tags?.map(
-              (tag) =>
-                html`<span
+                    (tag) =>
+                      html`<span
                         class="tag water"
                         @click="${() => this.setFilterTag(tag)}"
                         >${this.tagToHumanReadable(tag)}</span
                       > `
-            )}
+                  )}
                 </div>
               </li>`
-    )}
+          )}
         </ul>
       </div>
     `;
@@ -425,6 +425,8 @@ export class RecipesListView extends LitElement {
       location.hostname === "127.0.0.1"
     ) {
       console.log(`Search event: "${this.filter}". GA disabled locally.`);
+    } else {
+      ga("send", "event", "cookbook", "search", this.filter);
     }
   }
 

--- a/frontend/views/recipes-list-view.ts
+++ b/frontend/views/recipes-list-view.ts
@@ -333,7 +333,7 @@ export class RecipesListView extends LitElement {
             </h6>
             <vaadin-checkbox-group @value-changed=${this.tagFilterChange}>
               ${this.tags.map(
-                (tag) => html`
+      (tag) => html`
                   <vaadin-checkbox
                     value="${tag}"
                     ?checked=${this.filterTags.includes(tag)}
@@ -346,23 +346,23 @@ export class RecipesListView extends LitElement {
                     ></vaadin-checkbox
                   >
                 `
-              )}
+    )}
             </vaadin-checkbox-group>
           </vaadin-details>
         </div>
         <ul class="recipes-list">
           ${repeat(
-            recipes.filter((recipe) =>
-              this.recipeMatches(recipe, this.filter, this.filterTags)
-            ),
-            (recipe) => recipe.url,
-            (recipe) =>
-              html` <li class="recipe">
+      recipes.filter((recipe) =>
+        this.recipeMatches(recipe, this.filter, this.filterTags)
+      ),
+      (recipe) => recipe.url,
+      (recipe) =>
+        html` <li class="recipe">
                 <h5 class="recipe-title">
                   <a href="${recipe.url}"
                     >${recipe.howDoI
-                      .trim()
-                      .replace(/^\w/, (c) => c.toUpperCase())}</a
+            .trim()
+            .replace(/^\w/, (c) => c.toUpperCase())}</a
                   >
                 </h5>
                 <p
@@ -373,16 +373,16 @@ export class RecipesListView extends LitElement {
                 </p>
                 <div class="recipe-tags">
                   ${recipe.tags?.map(
-                    (tag) =>
-                      html`<span
+              (tag) =>
+                html`<span
                         class="tag water"
                         @click="${() => this.setFilterTag(tag)}"
                         >${this.tagToHumanReadable(tag)}</span
                       > `
-                  )}
+            )}
                 </div>
               </li>`
-          )}
+    )}
         </ul>
       </div>
     `;
@@ -425,8 +425,6 @@ export class RecipesListView extends LitElement {
       location.hostname === "127.0.0.1"
     ) {
       console.log(`Search event: "${this.filter}". GA disabled locally.`);
-    } else {
-      ga("send", "event", "cookbook", "search", this.filter);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@polymer/iron-icon": "3.0.1",
     "@polymer/iron-list": "3.1.0",
     "@polymer/polymer": "3.2.0",
+    "@types/google.analytics": "0.0.40",
     "@vaadin/flow-frontend": "./target/flow-frontend",
     "@vaadin/form": "./target/flow-frontend/form",
     "@vaadin/router": "1.7.2",
@@ -160,6 +161,6 @@
       "lit-html": "1.2.1",
       "@types/validator": "10.11.3"
     },
-    "hash": "7aeaed20d92710ecda17ebe527660336e92d4221107d538e0f5a6bb9f40f1ce6"
+    "hash": "e931d62c48c99ddd98c499fdab3aaab678161c328aaafc89199d042b9ab2cf17"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@polymer/iron-icon": "3.0.1",
     "@polymer/iron-list": "3.1.0",
     "@polymer/polymer": "3.2.0",
-    "@types/google.analytics": "0.0.40",
     "@vaadin/flow-frontend": "./target/flow-frontend",
     "@vaadin/form": "./target/flow-frontend/form",
     "@vaadin/router": "1.7.2",
@@ -161,6 +160,6 @@
       "lit-html": "1.2.1",
       "@types/validator": "10.11.3"
     },
-    "hash": "e931d62c48c99ddd98c499fdab3aaab678161c328aaafc89199d042b9ab2cf17"
+    "hash": "7aeaed20d92710ecda17ebe527660336e92d4221107d538e0f5a6bb9f40f1ce6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,6 @@ dependencies:
   '@polymer/iron-icon': 3.0.1
   '@polymer/iron-list': 3.1.0
   '@polymer/polymer': 3.2.0
-  '@types/google.analytics': 0.0.40
   '@vaadin/flow-frontend': 'link:target/flow-frontend'
   '@vaadin/form': 'link:target/flow-frontend/form'
   '@vaadin/router': 1.7.2
@@ -1138,10 +1137,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
-  /@types/google.analytics/0.0.40:
-    dev: false
-    resolution:
-      integrity: sha512-R3HpnLkqmKxhUAf8kIVvDVGJqPtaaZlW4yowNwjOZUTmYUQEgHh8Nh5wkSXKMroNAuQM8gbXJHmNbbgA8tdb7Q==
   /@types/json-schema/7.0.6:
     dev: true
     resolution:
@@ -3029,12 +3024,14 @@ packages:
   /debug/3.2.6:
     dependencies:
       ms: 2.1.2
+    deprecated: 'Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)'
     dev: true
     resolution:
       integrity: sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   /debug/4.1.1:
     dependencies:
       ms: 2.1.2
+    deprecated: 'Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)'
     dev: true
     resolution:
       integrity: sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -7536,7 +7533,6 @@ specifiers:
   '@polymer/iron-icon': 3.0.1
   '@polymer/iron-list': 3.1.0
   '@polymer/polymer': 3.2.0
-  '@types/google.analytics': 0.0.40
   '@types/validator': 10.11.3
   '@vaadin/flow-frontend': ./target/flow-frontend
   '@vaadin/form': ./target/flow-frontend/form

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,6 @@ dependencies:
   '@polymer/iron-icon': 3.0.1
   '@polymer/iron-list': 3.1.0
   '@polymer/polymer': 3.2.0
-  '@types/google.analytics': 0.0.40
   '@vaadin/flow-frontend': 'link:target/flow-frontend'
   '@vaadin/form': 'link:target/flow-frontend/form'
   '@vaadin/router': 1.7.2
@@ -1138,10 +1137,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
-  /@types/google.analytics/0.0.40:
-    dev: false
-    resolution:
-      integrity: sha512-R3HpnLkqmKxhUAf8kIVvDVGJqPtaaZlW4yowNwjOZUTmYUQEgHh8Nh5wkSXKMroNAuQM8gbXJHmNbbgA8tdb7Q==
   /@types/json-schema/7.0.6:
     dev: true
     resolution:
@@ -7536,7 +7531,6 @@ specifiers:
   '@polymer/iron-icon': 3.0.1
   '@polymer/iron-list': 3.1.0
   '@polymer/polymer': 3.2.0
-  '@types/google.analytics': 0.0.40
   '@types/validator': 10.11.3
   '@vaadin/flow-frontend': ./target/flow-frontend
   '@vaadin/form': ./target/flow-frontend/form

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ dependencies:
   '@polymer/iron-icon': 3.0.1
   '@polymer/iron-list': 3.1.0
   '@polymer/polymer': 3.2.0
+  '@types/google.analytics': 0.0.40
   '@vaadin/flow-frontend': 'link:target/flow-frontend'
   '@vaadin/form': 'link:target/flow-frontend/form'
   '@vaadin/router': 1.7.2
@@ -1137,6 +1138,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
+  /@types/google.analytics/0.0.40:
+    dev: false
+    resolution:
+      integrity: sha512-R3HpnLkqmKxhUAf8kIVvDVGJqPtaaZlW4yowNwjOZUTmYUQEgHh8Nh5wkSXKMroNAuQM8gbXJHmNbbgA8tdb7Q==
   /@types/json-schema/7.0.6:
     dev: true
     resolution:
@@ -7531,6 +7536,7 @@ specifiers:
   '@polymer/iron-icon': 3.0.1
   '@polymer/iron-list': 3.1.0
   '@polymer/polymer': 3.2.0
+  '@types/google.analytics': 0.0.40
   '@types/validator': 10.11.3
   '@vaadin/flow-frontend': ./target/flow-frontend
   '@vaadin/form': ./target/flow-frontend/form

--- a/src/main/java/com/vaadin/recipes/recipe/alwayseditablelabel/AlwaysEditableLabel.java
+++ b/src/main/java/com/vaadin/recipes/recipe/alwayseditablelabel/AlwaysEditableLabel.java
@@ -1,6 +1,6 @@
 package com.vaadin.recipes.recipe.alwayseditablelabel;
 
-import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.router.Route;
 import com.vaadin.recipes.recipe.Metadata;
@@ -9,18 +9,17 @@ import com.vaadin.recipes.recipe.Tag;
 
 @Route("always-editable-label")
 @Metadata(
-        howdoI = "Create an always-editable Label",
-        description = "Create a Label component that is always in editable mode.",
+        howdoI = "Create an always-editable label",
+        description = "Create a component with a text label that is always in editable mode.",
         tags = { Tag.JAVA })
 public class AlwaysEditableLabel extends Recipe {
 
     public AlwaysEditableLabel() {
-        Label label = new Label("I'm an editable label ... ");
+        Span label = new Span("I'm an editable label ... ");
         label.getElement().setAttribute("contenteditable", true);
 
         label.getElement().addEventListener("input",
-                e -> Notification.show("Value changed: "
-                        + e.getEventData().getString("event.target.innerHTML")))
+                e -> Notification.show("Value changed: " + e.getEventData().getString("event.target.innerHTML")))
                 .addEventData("event.target.innerHTML");
 
         add(label);

--- a/src/main/java/com/vaadin/recipes/recipe/editablelabelondblclick/EditableLabelOnDblClick.java
+++ b/src/main/java/com/vaadin/recipes/recipe/editablelabelondblclick/EditableLabelOnDblClick.java
@@ -1,6 +1,6 @@
 package com.vaadin.recipes.recipe.editablelabelondblclick;
 
-import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
 import com.vaadin.recipes.recipe.Metadata;
@@ -9,14 +9,14 @@ import com.vaadin.recipes.recipe.Tag;
 
 @Route("editable-label-on-dblclick")
 @Metadata(
-        howdoI = "create an editable Label when double-clicked", 
-        description = "Create a Label that can turn into a text field for editing on double-click.",
+        howdoI = "create an editable label when double-clicked",
+        description = "Create a text label that can turn into a text field for editing on double-click.",
         tags = { Tag.JAVA })
 public class EditableLabelOnDblClick extends Recipe {
 
     public EditableLabelOnDblClick() {
         String initialContent = "Double-click me to edit ...";
-        Label label = new Label(initialContent);
+        Span label = new Span(initialContent);
         TextField textField = new TextField();
         textField.setValue(initialContent);
 


### PR DESCRIPTION
Still using preview.vaadin.com URL, as HaaS is not yet production-ready.

Removed the custom Google Analytics tracker, as HaaS should include that already. Not sure if the `<meta name="google-site-verification" ...>` is still needed. 

TODO We should use `haas.tracker.gtm. triggerGAEvent ` instead of the global `ga` method for sending tracking events.

TODO: also, why are we using JS to create the `<link>` elements? Why not just put them in the HTML directly?