### PR TITLE
Incorrect source file name

### DIFF
--- a/src/main/java/com/vaadin/recipes/recipe/prefixsuffixutil/PrefixUtilView.java
+++ b/src/main/java/com/vaadin/recipes/recipe/prefixsuffixutil/PrefixUtilView.java
@@ -12,7 +12,7 @@ import com.vaadin.recipes.recipe.Recipe;
 @Metadata(
     howdoI = "Add prefix to components with input fields",
     description = "Some components do have prefix slot, but do not have Java API yet to add the components to them. This recipe shows how to add components to those slots.",
-    sourceFiles = { "PrefixSuffixUtil.java" },
+    sourceFiles = { "PrefixUtil.java" },
     tags = {}
 )
 public class PrefixUtilView extends Recipe {


### PR DESCRIPTION
Fixes the `<Not found>` issue on the "PrefixSuffixUtil.java" tab (see https://cookbook.vaadin.com/prefix-util ) caused by wrong `sourceFiles` property value.