### PR TITLE
Allow MenuBar overflow button

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3808,6 +3808,7 @@ packages:
     resolution:
       integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
   /fsevents/2.1.3:
+    deprecated: '"Please update to latest v2.3 or v2.2"'
     dev: true
     engines:
       node: ^8.16.0 || ^10.6.0 || >=11.0.0
@@ -4301,6 +4302,7 @@ packages:
     resolution:
       integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
   /ini/1.3.5:
+    deprecated: Please update to ini >=1.3.6 to avoid a prototype pollution issue
     dev: true
     resolution:
       integrity: sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==

--- a/src/main/java/com/vaadin/recipes/recipe/overflowingmenubar/OverflowingMenuBarRecipe.java
+++ b/src/main/java/com/vaadin/recipes/recipe/overflowingmenubar/OverflowingMenuBarRecipe.java
@@ -1,0 +1,90 @@
+package com.vaadin.recipes.recipe.overflowingmenubar;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.Unit;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.menubar.MenuBar;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.router.Route;
+import com.vaadin.recipes.recipe.Metadata;
+import com.vaadin.recipes.recipe.Recipe;
+import com.vaadin.recipes.recipe.Tag;
+
+import java.time.LocalDate;
+
+@Route("overflowing-menubar")
+@Metadata(
+        howdoI = "Allow MenuBar overflow button",
+        description = "MenuBar automatically creates an overflow button when the buttons do not fit into MenuBar's width." +
+                " However, if you need a MenuBar inside a HorizontalLayout (f.e. a toolbar) it won't shrink as expected.",
+        tags = Tag.LAYOUT
+)
+public class OverflowingMenuBarRecipe extends Recipe {
+
+    public OverflowingMenuBarRecipe() {
+        this.add(new Div(new Text("Simple MenuBar creates an overflow button.")));
+        final var widerMenuBar = createWiderMenuBar();
+        widerMenuBar.setWidthFull(); // <-- fits to parent, allows shrinking and then growing
+        this.add(widerMenuBar);
+
+        /* *** */
+        this.add(new Div(new Text("MenuBar inside a HorizontalLayout does not create an overflow button properly.")));
+        final var notWorkingMenuBar = createMenuBar();
+        notWorkingMenuBar.addThemeName(ButtonVariant.LUMO_ERROR.getVariantName());
+        notWorkingMenuBar.setWidthFull(); // <-- Is not enough! Does not shrink.
+
+        final HorizontalLayout notWorkingToolbar = createFullWidthHorizontalLayout(notWorkingMenuBar);
+        this.add(notWorkingToolbar);
+
+        /* *** */
+        this.add(new Div(new Text("This shrinks the MenuBar when needed and grows it back.")));
+        final var menuBar = createMenuBar();
+        menuBar.addThemeName(ButtonVariant.LUMO_SUCCESS.getVariantName());
+        // 3 em is to accommodate the overflow button (triple dot)
+        menuBar.setMinWidth(3, Unit.EM); // <-- !!! needed to change min-width from `auto` so it could shrink !!!
+
+        final HorizontalLayout toolbar = createFullWidthHorizontalLayout(menuBar);
+        toolbar.expand(menuBar); // <-- flex-grow so it could grow when upsizing
+        // also would work with `menuBar.setWidthFull()` instead of `toolbar.expand(menuBar)`
+//         menuBar.setWidthFull();
+        this.add(toolbar);
+    }
+
+    private HorizontalLayout createFullWidthHorizontalLayout(MenuBar menuBar) {
+        final var toolbar = new HorizontalLayout(menuBar);
+        toolbar.add(createOtherFields());
+        toolbar.setWidthFull(); // <--
+        return toolbar;
+    }
+
+    private MenuBar createMenuBar() {
+        final var menuBar = new MenuBar();
+        addMenuItems(menuBar);
+        return menuBar;
+    }
+
+    private MenuBar createWiderMenuBar() {
+        final var menuBar = createMenuBar();
+        addMenuItems(menuBar);
+        return menuBar;
+    }
+
+    private void addMenuItems(MenuBar menuBar) {
+        menuBar.addItem("Try");
+        menuBar.addItem("resizing");
+        menuBar.addItem("the");
+        menuBar.addItem("browser");
+        menuBar.addItem("window");
+    }
+
+    private Component[] createOtherFields() {
+        return new Component[]{
+                new TextField(null, "Random text"),
+                new DatePicker(LocalDate.now())
+        };
+    }
+}

--- a/src/main/java/com/vaadin/recipes/recipe/overflowingmenubar/OverflowingMenuBarRecipe.java
+++ b/src/main/java/com/vaadin/recipes/recipe/overflowingmenubar/OverflowingMenuBarRecipe.java
@@ -58,6 +58,7 @@ public class OverflowingMenuBarRecipe extends Recipe {
         final var toolbar = new HorizontalLayout(menuBar);
         toolbar.add(createOtherFields());
         toolbar.setWidthFull(); // <--
+        toolbar.setDefaultVerticalComponentAlignment(Alignment.CENTER);
         return toolbar;
     }
 

--- a/src/main/java/com/vaadin/recipes/recipe/overflowingmenubar/OverflowingMenuBarRecipe.java
+++ b/src/main/java/com/vaadin/recipes/recipe/overflowingmenubar/OverflowingMenuBarRecipe.java
@@ -2,7 +2,6 @@ package com.vaadin.recipes.recipe.overflowingmenubar;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Text;
-import com.vaadin.flow.component.Unit;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.html.Div;
@@ -44,8 +43,8 @@ public class OverflowingMenuBarRecipe extends Recipe {
         this.add(new Div(new Text("This shrinks the MenuBar when needed and grows it back.")));
         final var menuBar = createMenuBar();
         menuBar.addThemeName(ButtonVariant.LUMO_SUCCESS.getVariantName());
-        // 3 em is to accommodate the overflow button (triple dot)
-        menuBar.setMinWidth(3, Unit.EM); // <-- !!! needed to change min-width from `auto` so it could shrink !!!
+        // size is to accommodate the overflow button (triple dot), for LARGE variant --lumo-size-l would be needed
+        menuBar.setMinWidth("var(--lumo-size-m)"); // <-- ! needed to change min-width from `auto` so it could shrink !
 
         final HorizontalLayout toolbar = createFullWidthHorizontalLayout(menuBar);
         toolbar.expand(menuBar); // <-- flex-grow so it could grow when upsizing


### PR DESCRIPTION
Closes #164 

MenuBar automatically creates an overflow button when the buttons do not fit into MenuBar's width. However, if you need a MenuBar inside a HorizontalLayout (f.e. a toolbar) it won't shrink as expected.

In the recipe I provide a comparison of 3 MenuBar uses:

1. MenuBar **not** inside HorizontalLayout working as expected
    - uses `width: 100%`
2. MenuBar inside HorizontalLayout but overflowing the parent layout without overflow button
    - uses `width: 100%`
3. MenuBar inside HorizontalLayout working as expected
    - uses `min-width`
    - uses `flex-grow`, resp. expand (optionally `width: 100%`)

Not resized:
![image](https://user-images.githubusercontent.com/37943001/104949129-baf1d000-59be-11eb-87a9-e9f8400aa99a.png)

Resized (the middle red HL is overflowing the parent VL, see the width of the dark code-viewer):
![image](https://user-images.githubusercontent.com/37943001/104949080-a7df0000-59be-11eb-88fb-2e0d0ab702b3.png)

