### PR TITLE
Excel like cell selection in a grid

### DIFF
--- a/frontend/recipe/gridexcellikecellselection/gridexcellikecellselection.js
+++ b/frontend/recipe/gridexcellikecellselection/gridexcellikecellselection.js
@@ -1,0 +1,193 @@
+if (!window.Vaadin.Flow.custom) {
+    window.Vaadin.Flow.custom = {};
+}
+
+/**
+ * A function that adds mouse event listeners to the given grid to select
+ * cells like in Excel. Starts with a mouse down event and fires a
+ * custom event "excel-like-selected-cells" on mouse up.
+ * @param grid grid to extend
+ */
+window.Vaadin.Flow.custom.initGridExcelCellSelection = function (grid) {
+
+    let startTdOfMove;
+    let selectedKeys = new Set();
+    let selectedColumns = new Set();
+    let selectedIndexes = new Set();
+
+    /**
+     * Returns the inner table of the grid.
+     */
+    function getInnerTable() {
+        return grid.$.table;
+    }
+
+
+    /**
+     * Checks, whether the given element is either a vaadin grid cell or a td. In the first case, returns the
+     * containing TD, in the second case the element itself. In all other cases undefined.
+     */
+    function getTdElement(element) {
+        if (element.tagName === "VAADIN-GRID-CELL-CONTENT") {
+            return element.offsetParent;
+        }
+        return element.tagName === "TD" ? element : undefined;
+    }
+
+    /**
+     * Checks, whether the given event target is either a vaadin grid cell or a td. In the first case, returns the
+     * containing TD, in the second case the element itself. In all other cases undefined.
+     */
+    function getTdElementFromEvent(event) {
+        return getTdElement(event.target);
+    }
+
+    /**
+     * Marks the given element (either a vaadin grid cell or td) visually as "selected". Does not modify the internal
+     * selection cache.
+     */
+    function addSelectedStyle(element) {
+        let td = getTdElement(element);
+        if (td) {
+            td.style.backgroundColor = "gray";
+            return td;
+        }
+        return undefined;
+    }
+
+    /**
+     * Removes the visual "selected" mark from the given element (either a vaadin grid cell or td) visually.
+     * Does not modify the internal selection cache.
+     */
+    function removeSelectedStyle(element) {
+        let td = getTdElement(element);
+        if (td) {
+            td.style.backgroundColor = "";
+            return td;
+        }
+        return undefined;
+    }
+
+
+    /**
+     * Remove all visual "selected" styles.
+     */
+    function removeAllSelectedStyles() {
+        getInnerTable().querySelectorAll("td").forEach(element => {
+            removeSelectedStyle(element);
+        });
+    }
+
+    /**
+     * Interpretes the data from the given TD and adds it to the internal selection cache.
+     */
+    function addToCache(td) {
+        selectedKeys.add(grid.__getRowModel(td.parentNode).item.key);
+        selectedIndexes.add(td.parentNode.index);
+
+        if (td._column && td._column._flowId) {
+            selectedColumns.add(td._column._flowId);
+        }
+    }
+
+    /**
+     * Clears the internal selection caches. Does not modify the "startTdToMove" variable.
+     */
+    function clearCaches() {
+        // do not clear the startTdToMove in here!
+        selectedKeys.clear();
+        selectedColumns.clear();
+        selectedIndexes.clear();
+    }
+
+    /**
+     * This listener marks all table data cells between the "startTdOfMove" element and the event target (when
+     * that refers to a TD, too) as selected (visually and in selection cache).
+     */
+    function mouseMoveEventListener(event) {
+        if (!startTdOfMove) {
+            console.warn("no start td cached, maybe the grid element was clicked");
+        } else {
+            // no need to check for mouse down, since we only add this listener on mousedown event
+            let td = getTdElementFromEvent(event);
+            if (td) {
+                clearCaches();
+                removeAllSelectedStyles();
+
+                let table = getInnerTable();
+
+                let startRowOfMove = startTdOfMove.parentNode.rowIndex;
+                let startCellOfMove = startTdOfMove.cellIndex;
+                let currentRow = td.parentNode.rowIndex;
+                let currentCell = td.cellIndex;
+
+                let initRow = startRowOfMove <= currentRow ? startRowOfMove : currentRow;
+                let maxRow = startRowOfMove <= currentRow ? currentRow : startRowOfMove;
+
+                let initCell = startCellOfMove <= currentCell ? startCellOfMove : currentCell;
+                let maxCell = startCellOfMove <= currentCell ? currentCell : startCellOfMove;
+
+                for (let row = initRow; row <= maxRow; row++) {
+                    for (let cell = initCell; cell <= maxCell; cell++) {
+                        let tdToMark = table.rows[row].cells[cell];
+                        if (tdToMark) {
+                            addToCache(tdToMark);
+                            addSelectedStyle(tdToMark);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // update td styles on scroll - this is necessary since the grid reuses the inner table cells for new data
+    // this leads to marked cells, even if the data itself has not been selected
+    getInnerTable().addEventListener("scroll", event => {
+        let table = event.target;
+        table.querySelectorAll("td").forEach(td => {
+            if(selectedIndexes.has(td.parentNode.index) && selectedColumns.has(td._column._flowId)) {
+                addSelectedStyle(td);
+            } else {
+                removeSelectedStyle(td);
+            }
+        });
+    });
+
+    // Initiates the cell selection. Sets the event target td as start td.
+    grid.addEventListener("mousedown", event => {
+        const innerTable = getInnerTable();
+
+        // prevent default text selection (looks strange)
+        innerTable.style.userSelect = "none";
+
+        // update selections
+        clearCaches();
+        removeAllSelectedStyles();
+
+        let td = getTdElementFromEvent(event);
+        if (td) {
+            startTdOfMove = td;
+            addSelectedStyle(td);
+            addToCache(td);
+        } else {
+            startTdOfMove = undefined;
+        }
+
+        grid.addEventListener("mousemove", mouseMoveEventListener);
+    });
+
+    // Stops the cell selection and fires the custom event to the server.
+    grid.addEventListener("mouseup", e => {
+        startTdOfMove = undefined;
+        grid.dispatchEvent(new CustomEvent("excel-like-selected-cells", {
+            detail: {
+                selectedKeys: Array.from(selectedKeys.values()),
+                selectedColumns: Array.from(selectedColumns.values())
+            }
+        }))
+        getInnerTable().style.userSelect = "";
+        grid.removeEventListener("mousemove", mouseMoveEventListener)
+    });
+
+};
+

--- a/src/main/java/com/vaadin/recipes/recipe/gridexcellikecellselection/GridExcelLikeCellSelection.java
+++ b/src/main/java/com/vaadin/recipes/recipe/gridexcellikecellselection/GridExcelLikeCellSelection.java
@@ -1,0 +1,158 @@
+package com.vaadin.recipes.recipe.gridexcellikecellselection;
+
+import com.vaadin.flow.component.dependency.JavaScript;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.component.html.H5;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.recipes.recipe.Metadata;
+import com.vaadin.recipes.recipe.Recipe;
+import com.vaadin.recipes.recipe.Tag;
+import elemental.json.JsonArray;
+import elemental.json.JsonObject;
+import elemental.json.JsonValue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Route(value = "grid-excel-like-cell-selection")
+@JavaScript("./recipe/gridexcellikecellselection/gridexcellikecellselection.js")
+@Metadata(
+        howdoI = "Excel like cell selection in a grid",
+        description = "Code example for selecting cells in a grid similar to Excel. Server side gets informed about " +
+                "selected items and columns.",
+        sourceFiles = {"recipe/gridexcellikecellselection/gridexcellikecellselection.js"},
+        tags = {Tag.GRID}
+)
+public class GridExcelLikeCellSelection extends Recipe {
+
+    private final Grid<SamplePerson> grid;
+    private final VerticalLayout results;
+
+    public GridExcelLikeCellSelection() {
+        grid = new Grid<>(SamplePerson.class, false);
+
+        grid.addColumn("id").setAutoWidth(true);
+        grid.addColumn("firstName").setAutoWidth(true);
+        grid.addColumn("lastName").setAutoWidth(true);
+        grid.addColumn("email").setAutoWidth(true);
+
+        grid.setItems(SamplePerson.ITEMS);
+
+        initExcelLikeCellSelection();
+
+        results = new VerticalLayout();
+
+        HorizontalLayout layout = new HorizontalLayout(grid, results);
+        layout.setSizeFull();
+        grid.setWidthFull();
+
+        add(layout);
+    }
+
+    /**
+     * Initiates the excel like cell selection
+     */
+    private void initExcelLikeCellSelection() {
+        // Applies the necessary client side event logic to the given grid
+        grid.getElement().executeJs("window.Vaadin.Flow.custom.initGridExcelCellSelection(this)");
+
+        // Adds a event listener, that receives the client side fired event to read the selected items and columns.
+        // A subclass of Grid could also use a custom @DomEvent annotated event class, e.g. ExcelLikeSelectedCellsEvent
+        grid.getElement().addEventListener("excel-like-selected-cells", event -> {
+            JsonObject eventData = event.getEventData();
+            results.removeAll();
+            results.add(new H3("Selection results"));
+
+            VerticalLayout items = new VerticalLayout();
+
+            items.add(new H5("Selected Items"));
+
+            JsonValue value = eventData.get("event.detail.selectedKeys");
+            if (value instanceof JsonArray) {
+                JsonArray array = (JsonArray) value;
+                for (int i = 0; i < array.length(); i++) {
+                    String key = array.getString(i);
+                    SamplePerson item = grid.getDataCommunicator().getKeyMapper().get(key);
+                    if (item != null) {
+                        items.add(new Span(item.toString()));
+                    }
+                }
+            }
+
+            VerticalLayout columns = new VerticalLayout();
+            columns.add(new H5("Selected Columns"));
+            value = eventData.get("event.detail.selectedColumns");
+            if (value instanceof JsonArray) {
+                JsonArray array = (JsonArray) value;
+                for (int i = 0; i < array.length(); i++) {
+                    String key = array.getString(i);
+                    columns.add(new Span(key));
+                }
+            }
+
+            results.add(items, columns);
+        }).addEventData("event.detail.selectedKeys").addEventData("event.detail.selectedColumns");
+    }
+
+    public static class SamplePerson {
+        public static final List<SamplePerson> ITEMS;
+
+        static {
+            ITEMS = new ArrayList<>(10);
+            for (int i = 0; i < 200; i++) {
+                ITEMS.add(new SamplePerson(i, "First Name " + i, "Last Name " + i, "person" + i + "@example.com"));
+            }
+        }
+
+        private final int id;
+        private final String firstName;
+        private final String lastName;
+        private final String email;
+
+        public SamplePerson(int id, String firstName, String lastName, String email) {
+            this.id = id;
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.email = email;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+        public String getLastName() {
+            return lastName;
+        }
+        public String getEmail() {
+            return email;
+        }
+
+        @Override
+        public String toString() {
+            return "Person " + id;
+
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            SamplePerson that = (SamplePerson) o;
+            return id == that.id;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id);
+        }
+    }
+}


### PR DESCRIPTION
## Description

This example shows on how an Excel like cell selection could be implemented for the Vaadin Grid. Based on the selected cells an event is fired containing all selected items and columns, so that the server side (or whoever listens) can react on the selected items. 
