### PR TITLE
fix: prefer refreshItem over refreshAll

### DIFF
--- a/src/main/java/com/vaadin/recipes/recipe/treegridsubtreehighlight/TreeGridSubTreeHighlight.java
+++ b/src/main/java/com/vaadin/recipes/recipe/treegridsubtreehighlight/TreeGridSubTreeHighlight.java
@@ -17,6 +17,8 @@ import com.vaadin.recipes.recipe.Recipe;
 @CssImport(themeFor = "vaadin-grid", value = "./recipe/treegridsubtreehighlight/treegrid-subtree-highlight.css")
 public class TreeGridSubTreeHighlight extends Recipe {
 
+    private TreeGrid<Department> grid;
+
     public TreeGridSubTreeHighlight() {
         this.setSizeFull();
         createBasicTreeGridUsage();
@@ -25,7 +27,7 @@ public class TreeGridSubTreeHighlight extends Recipe {
     private void createBasicTreeGridUsage() {
         DepartmentData departmentData = new DepartmentData();
 
-        TreeGrid<Department> grid = new TreeGrid<>();
+        grid = new TreeGrid<>();
 
         grid.setItems(departmentData.getRootDepartments(), departmentData::getChildDepartments);
         grid.addHierarchyColumn(Department::getName).setHeader("Department Name");
@@ -35,7 +37,8 @@ public class TreeGridSubTreeHighlight extends Recipe {
             .asSingleSelect()
             .addValueChangeListener(
                 event -> {
-                    grid.getDataProvider().refreshAll();
+                    refreshChildItems(event.getOldValue());
+                    refreshChildItems(event.getValue());
                 }
             );
 
@@ -49,7 +52,15 @@ public class TreeGridSubTreeHighlight extends Recipe {
                 } else return null;
             }
         );
-        grid.setHeightByRows(true);
+        grid.setAllRowsVisible(true);
         add(grid);
+    }
+
+    private void refreshChildItems(Department department) {
+        if (department != null) {
+            grid.getTreeData().getChildren(department).forEach(child -> {
+                grid.getDataProvider().refreshItem(child, false);
+            });
+         }
     }
 }


### PR DESCRIPTION
Related to https://github.com/vaadin/flow-components/issues/1050

Avoid using `dataProvider.refreshAll()` where it's not necessary. This PR changes the `treegrid-subtree-highlight` example to use `refreshItem` instead to avoid the quite noticeable flickering on selection:

Before:

https://user-images.githubusercontent.com/1222264/139843455-f1fb7356-e878-485b-8cc3-9044c1c400a7.mp4

After:

https://user-images.githubusercontent.com/1222264/139843475-4373e16b-04b0-4ee1-bad5-a147022fd399.mp4

