### PR TITLE
fix: replace deprecated addListener for oslightdarktheme

### DIFF
--- a/frontend/recipe/oslightdarktheme/prefers-color-scheme.js
+++ b/frontend/recipe/oslightdarktheme/prefers-color-scheme.js
@@ -8,5 +8,7 @@ window.applyTheme = () => {
 };
 window
   .matchMedia("(prefers-color-scheme: dark)")
-  .addListener(window.applyTheme);
+  .addEventListener('change', function () {
+      window.applyTheme()
+  });
 window.applyTheme();


### PR DESCRIPTION
## Description

The oslightdarktheme recipe uses the deprecated javascript function 'addListener'. It's replaced by the recommended 'addEventListener' function.

Fixes # (noissue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [-] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
