### PR TITLE
fix: fix initialization of I18N weekdays

### DIFF
--- a/src/main/java/com/vaadin/recipes/recipe/datepicker18n/DatePickerI18NExample.java
+++ b/src/main/java/com/vaadin/recipes/recipe/datepicker18n/DatePickerI18NExample.java
@@ -41,8 +41,8 @@ public class DatePickerI18NExample extends Recipe {
     DateFormatSymbols dfs = DateFormatSymbols.getInstance(locale);
 
     i18n.setMonthNames(List.of(dfs.getMonths()));
-    i18n.setWeekdays(List.of(dfs.getWeekdays()));
-    i18n.setWeekdaysShort(List.of(dfs.getShortWeekdays()));
+    i18n.setWeekdays(List.of(dfs.getWeekdays()).stream().skip(1).toList());
+    i18n.setWeekdaysShort(List.of(dfs.getShortWeekdays()).stream().skip(1).toList());
     i18n.setDateFormat(getPattern(locale, yearFormat));
 
     DayOfWeek firstDayOfWeek = WeekFields.of(locale).getFirstDayOfWeek();


### PR DESCRIPTION
## Description

As discussed in https://github.com/vaadin/flow-components/issues/6353#issuecomment-2175966174, the result of `DateFormatSymbols.getWeekdays` and `DateFormatSymbols.getShortWeekdays` returns 8 items instead of 7.

> For example:
> 
> ```java
> System.out.println(String.join(",", dfs.getWeekdays()));
> System.out.println(String.join(",", dfs.getShortWeekdays()));
> ```
> 
> Prints:
> 
> ```
> ,Sunday,Monday,Tuesday,Wednesday,Thursday,Friday,Saturday
> ,Sun,Mon,Tue,Wed,Thu,Fri,Sat
> ```

Fixes #329

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
