### PR TITLE
fix: production artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,7 @@
                         <executions>
                             <execution>
                                 <goals>
+                                    <goal>prepare-frontend</goal>
                                     <goal>build-frontend</goal>
                                 </goals>
                             </execution>


### PR DESCRIPTION
Without this change when we execute:
```
mvn clean package -Pproduction
java -jar target/*.jar
```
It runs in dev-mode opening the browser and failing 
```
Npm install has exited with non zero status
```
