### PR TITLE
Fix VerticalLayout import logic

### DIFF
--- a/frontend/code-viewer.ts
+++ b/frontend/code-viewer.ts
@@ -105,11 +105,11 @@ export class CodeViewer extends LitElement {
     if (!code) return "";
 
     code = code.substring(code.search(/^import/gm)); // remove package
-    if(language == "java") {
+    if(language == "java" && code.includes("extends Recipe")) {
         code = code.replace("extends Recipe", "extends VerticalLayout");
         // add VerticalLayout import if needed
         if(!code.includes("import com.vaadin.flow.component.orderedlayout.VerticalLayout")) {
-            code = "import com.vaadin.flow.component.orderedlayout.VerticalLayout\n" + code;
+            code = "import com.vaadin.flow.component.orderedlayout.VerticalLayout;\n" + code;
         }
     }
     code = this.removeMetadataTag(code);


### PR DESCRIPTION
## Description

Currently, there's some logic replacing extends Recipe with extends VerticalLayout and adds VerticalLayout import, but it doesn't have a semicolon at the end.
Furthermore, it adds VerticalLayout import to any Java code example.
This PR fixes these issues.

Fixes # (issue)
#352

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
  -  manual testing only
- [ ] New and existing tests are passing locally with my change.
  - manual testing only
- [x] I have performed self-review and corrected misspellings.
