### PR TITLE
More Split Button Layout examples

### DIFF
--- a/src/main/java/com/vaadin/recipes/recipe/splitbuttonbar/SplitButtonBar.java
+++ b/src/main/java/com/vaadin/recipes/recipe/splitbuttonbar/SplitButtonBar.java
@@ -19,7 +19,7 @@ import com.vaadin.recipes.recipe.Tag;
 public class SplitButtonBar extends Recipe {
 
     public SplitButtonBar() {
-        add(new H4("Use a individual item alignment (Since V24.7 - Recommended)"), withIndividualAlignment());
+        add(new H4("Use individual item alignment (Since V24.7 - Recommended)"), withIndividualAlignment());
         add(new H4("Use a wrapper layout and 'between' justification"), withBetween());
         add(new H4("Use a wrapper layout and expand"), withWrapperLayout());
         add(new H4("Set margin-right: auto on second button"), withMarginLeft());


### PR DESCRIPTION
## Description

Changes:
* Added a modern example of using `.addToStart(..)` and `.addToEnd(..)`
* Added example of using `buttonLayout.setJustifyContentMode(JustifyContentMode.BETWEEN);`

Fixes #334

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
