### PR TITLE
Rewrite "Offer a dynamic / generated file for download" recipe to use DownloadHandler

### DIFF
--- a/src/main/java/com/vaadin/recipes/recipe/downloadgeneratedfile/DownloadingDynamicallyGeneratedFile.java
+++ b/src/main/java/com/vaadin/recipes/recipe/downloadgeneratedfile/DownloadingDynamicallyGeneratedFile.java
@@ -1,21 +1,25 @@
 package com.vaadin.recipes.recipe.downloadgeneratedfile;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.streams.DownloadHandler;
+import com.vaadin.flow.server.streams.DownloadResponse;
 import com.vaadin.recipes.recipe.Metadata;
 import com.vaadin.recipes.recipe.Recipe;
 import com.vaadin.recipes.recipe.Tag;
-import org.vaadin.firitin.components.DynamicFileDownloader;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 
 @Route("dynamic-download")
 @Metadata(
         howdoI = "Offer a dynamic / generated file for download",
         description = "Shows how to allow the user to download a file generated on the server.",
-        tags = { Tag.DOWNLOAD }, addons = "Viritin;https://vaadin.com/directory/component/flow-viritin"
+        tags = { Tag.DOWNLOAD }
 )
 public class DownloadingDynamicallyGeneratedFile extends Recipe {
 
@@ -31,17 +35,24 @@ public class DownloadingDynamicallyGeneratedFile extends Recipe {
         var person = new PersonDto();
         binder.setBean(person);
 
-        // The actual download component and file generation
-        add(new DynamicFileDownloader("Download as JSON", outputStream -> {
+        var downloadHandler = DownloadHandler.fromInputStream(downloadEvent -> {
+            var outputValue = binder.getBean();
+            var outputStream = new ByteArrayOutputStream();
             // Using Jackson here to generate JSON to the output stream,
             // but could be just as well be XML, image or PDF
-            ObjectMapper objectMapper = new ObjectMapper();
-            objectMapper.writeValue(outputStream, person);
-        }).withFileNameGenerator(r -> {
-            // Using a FileNameGenerator, you can customize the
-            // name of the downloaded file
-            return person.getName().replaceAll(" ", "_") + ".json";
-        }));
+            var objectMapper = new ObjectMapper();
+            objectMapper.writeValue(outputStream, outputValue);
+
+            // Convert output stream to input stream
+            var inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+            return new DownloadResponse(inputStream,
+                    name.getValue().replaceAll(" ", "_") + ".json", // dynamic file name
+                    "application/json", // content type
+                    -1); // content length (-1 = unknown)
+        });
+
+        var link = new Anchor(downloadHandler, "Download as JSON");
+        add(link);
     }
 
     public static class PersonDto {

--- a/src/main/java/com/vaadin/recipes/recipe/downloadgeneratedfile/DownloadingDynamicallyGeneratedFile.java
+++ b/src/main/java/com/vaadin/recipes/recipe/downloadgeneratedfile/DownloadingDynamicallyGeneratedFile.java
@@ -23,6 +23,9 @@ import java.io.ByteArrayOutputStream;
 )
 public class DownloadingDynamicallyGeneratedFile extends Recipe {
 
+    // If you are using a Vaadin version older than 24.8, DownloadHandler will not be available to you.
+    // See DynamicFileDownloader from https://vaadin.com/directory/component/flow-viritin for an alternative.
+
     private TextField name = new TextField("Name");
     private IntegerField yearOfBirth = new IntegerField("Year of Birth");
 

--- a/src/main/java/com/vaadin/recipes/recipe/downloadgeneratedfile/DownloadingDynamicallyGeneratedFile.java
+++ b/src/main/java/com/vaadin/recipes/recipe/downloadgeneratedfile/DownloadingDynamicallyGeneratedFile.java
@@ -6,14 +6,9 @@ import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.server.streams.DownloadHandler;
-import com.vaadin.flow.server.streams.DownloadResponse;
 import com.vaadin.recipes.recipe.Metadata;
 import com.vaadin.recipes.recipe.Recipe;
 import com.vaadin.recipes.recipe.Tag;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 
 @Route("dynamic-download")
 @Metadata(
@@ -38,23 +33,15 @@ public class DownloadingDynamicallyGeneratedFile extends Recipe {
         var person = new PersonDto();
         binder.setBean(person);
 
-        var downloadHandler = DownloadHandler.fromInputStream(downloadEvent -> {
-            var outputValue = binder.getBean();
-            var outputStream = new ByteArrayOutputStream();
+        var link = new Anchor(event -> {
+            event.setFileName(name.getValue().replaceAll(" ", "_") + ".json");  // dynamic file name
+            event.setContentType("application/json");
+
             // Using Jackson here to generate JSON to the output stream,
             // but could be just as well be XML, image or PDF
             var objectMapper = new ObjectMapper();
-            objectMapper.writeValue(outputStream, outputValue);
-
-            // Convert output stream to input stream
-            var inputStream = new ByteArrayInputStream(outputStream.toByteArray());
-            return new DownloadResponse(inputStream,
-                    name.getValue().replaceAll(" ", "_") + ".json", // dynamic file name
-                    "application/json", // content type
-                    -1); // content length (-1 = unknown)
-        });
-
-        var link = new Anchor(downloadHandler, "Download as JSON");
+            objectMapper.writeValue(event.getOutputStream(), binder.getBean());
+        }, "Download as JSON");
         add(link);
     }
 


### PR DESCRIPTION
## Description

Changes:
* Rewrote recipe to use `DownloadHandler` instead of DynamicFileDownloader from Viritin addon.

Fixes #372
## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
  - Not relevant
- [ ] New and existing tests are passing locally with my change.
  - Not relevant
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
