### PR TITLE
Update "Show Formatted text" to use newer setWhiteSpace method

### DIFF
--- a/src/main/java/com/vaadin/recipes/recipe/formattext/FormatText.java
+++ b/src/main/java/com/vaadin/recipes/recipe/formattext/FormatText.java
@@ -1,28 +1,29 @@
 package com.vaadin.recipes.recipe.formattext;
 
+import com.vaadin.flow.component.HasText;
 import org.jsoup.Jsoup;
 import org.jsoup.safety.Safelist;
 
 import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.router.Route;
 import com.vaadin.recipes.recipe.Metadata;
 import com.vaadin.recipes.recipe.Recipe;
 import com.vaadin.recipes.recipe.Tag;
 
 @Route("format-text")
-@Metadata(howdoI = "show formatted text", description = "Different approaches for showing formatted text.", tags = {
-        Tag.FLOW })
+@Metadata(howdoI = "show formatted text",
+        description = "Different approaches for showing formatted text.",
+        tags = {Tag.FLOW })
 public class FormatText extends Recipe {
     public FormatText() {
-        Paragraph lineBreaks = new Paragraph("Text\nwith\nline\nbreaks");
-        lineBreaks.getStyle().setWhiteSpace(Style.WhiteSpace.PRE);
+        var lineBreaks = new Paragraph("Text\nwith\nline\nbreaks");
+        lineBreaks.setWhiteSpace(HasText.WhiteSpace.PRE);
 
-        Html html = new Html(Jsoup.clean("<p>Formatted <b>text</b><br>as <i>HTML</i></p>", Safelist.basic()));
+        var html = new Html(Jsoup.clean("<p>Formatted <b>text</b><br>as <i>HTML</i></p>", Safelist.basic()));
 
-        Paragraph elements = new Paragraph();
+        var elements = new Paragraph();
         elements.getElement().appendChild(Element.createText("Formatted "), new Element("b").setText("text"),
                 new Element("br"), Element.createText("as "), new Element("i").setText("elements"));
 
@@ -32,6 +33,6 @@ public class FormatText extends Recipe {
                 new Paragraph(
                         "For full formatting, you can use HTML either as a string or by assembling individual elements. "
                                 + "When using an HTML string, you should be careful to not include any user-provided values that might lead to cross-site scripting vulnerabilities."),
-                elements, html);
+                html, elements);
     }
 }


### PR DESCRIPTION
## Description

Replaced `lineBreaks.getStyle().setWhiteSpace(..)` with `lineBreaks.setWhiteSpace(..)`.
Also changed order of the examples to be a bit more in line with how they are ordered in code.

Fixes #378 (issue)

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist
- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
  - Not relevant
- [ ] New and existing tests are passing locally with my change.
  - Not relevant
- [x] I have performed self-review and corrected misspellings.