### PR TITLE
Replace pull_request_target with pull_request in CI workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,17 +7,15 @@ on:
 concurrency:
   group: ${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
     if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -2,38 +2,31 @@ name: Cookbook Validation
 on:
   push:
     branches: ['main']
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, edited]
 concurrency:
   group: ${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   build:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-cool/check-user-permission@main
-        id: checkUser
+      - uses: actions/checkout@v5
         with:
-          username: ${{github.triggering_actor}}
-          require: 'write'
-      - name: Fail on external workflow triggering
-        if: ${{ steps.checkUser.outputs.require-result != 'true' }}
-        run: |
-          echo "🚫 **${{ github.actor }}** is an external contributor, a **${{ github.repository }}** team member has to review this changes and re-run this build" \
-            | tee -a $GITHUB_STEP_SUMMARY && exit 1
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/cache@v3
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
-      - uses: stCarolas/setup-maven@v4.5
+      - uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.8.7
       - name: Install prokey


### PR DESCRIPTION
## Summary

Replaces `pull_request_target` with `pull_request` in `validation.yml`.

Removes the `actions-cool/check-user-permission` gate (unpinned `@main` reference). Build job skips entirely for fork PRs since `TB_LICENSE` is not available and is required at compile time with `-Pproduction`. Bumps all GitHub Actions from v3 to v5 and adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`.